### PR TITLE
Supporting out-of-source builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ matlab_runners/Feature Point Experiments/out_wild_svr_wild/
 matlab_runners/Feature Point Experiments/yt_features/
 matlab_runners/Feature Point Experiments/yt_features_clm/
 matlab_runners/Gaze Experiments/mpii_out/
+build/


### PR DESCRIPTION
This PR adds `build/` to the .gitignore file, so that multiple configurations can be compiled in separate directories without affecting the source files, e.g. `build/debug`, `build/release`.

More information on out-of-source builds can be found in the [cmake FAQ doc](https://cmake.org/Wiki/CMake_FAQ#Out-of-source_build_trees).

I'll update the wiki to suggest out-of-source builds once I figure out how to contribute to wikis on github.