### PR TITLE
Fix install in CMakeLists.txt files

### DIFF
--- a/exe/FaceLandmarkImg/CMakeLists.txt
+++ b/exe/FaceLandmarkImg/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(FaceLandmarkImg dlib)
 
 target_link_libraries(FaceLandmarkImg ${OpenCV_LIBS} ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 
-install (TARGETS FaceLandmarkImg DESTINATION ${CMAKE_BINARY_DIR}/bin)
+install (TARGETS FaceLandmarkImg DESTINATION bin)

--- a/exe/FaceLandmarkVid/CMakeLists.txt
+++ b/exe/FaceLandmarkVid/CMakeLists.txt
@@ -16,4 +16,4 @@ target_link_libraries(FaceLandmarkVid dlib)
 
 target_link_libraries(FaceLandmarkVid ${OpenCV_LIBS} ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 
-install (TARGETS FaceLandmarkVid DESTINATION ${CMAKE_BINARY_DIR}/bin)
+install (TARGETS FaceLandmarkVid DESTINATION bin)

--- a/exe/FaceLandmarkVidMulti/CMakeLists.txt
+++ b/exe/FaceLandmarkVidMulti/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(FaceLandmarkVidMulti dlib)
 
 target_link_libraries(FaceLandmarkVidMulti ${OpenCV_LIBS} ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 
-install (TARGETS FaceLandmarkVidMulti DESTINATION ${CMAKE_BINARY_DIR}/bin)
+install (TARGETS FaceLandmarkVidMulti DESTINATION bin)

--- a/lib/local/FaceAnalyser/CMakeLists.txt
+++ b/lib/local/FaceAnalyser/CMakeLists.txt
@@ -30,4 +30,4 @@ include_directories(../LandmarkDetector/include)
 add_library( FaceAnalyser ${SOURCE} ${HEADERS})
 
 install (TARGETS FaceAnalyser DESTINATION bin)
-install (FILES HEADERS DESTINATION include)
+install (FILES ${HEADERS} DESTINATION include)

--- a/lib/local/LandmarkDetector/CMakeLists.txt
+++ b/lib/local/LandmarkDetector/CMakeLists.txt
@@ -38,4 +38,4 @@ include_directories(${LandmarkDetector_SOURCE_DIR}/include)
 add_library( LandmarkDetector ${SOURCE} ${HEADERS})
 
 install (TARGETS LandmarkDetector DESTINATION bin)
-install (FILES HEADERS DESTINATION include)
+install (FILES ${HEADERS} DESTINATION include)


### PR DESCRIPTION
Although the library OpenFace compiles and the executables run fine, the command `sudo make install` doesn't work at all on my computer (Ubuntu 15.04, CMake 3.0.2).

For instance :
* In the file lib/local/LandmarkDetector/CMakeLists.txt, last line : shouldn't it be `${HEADERS}` instead of `HEADERS` ? I get an error otherwise when doing .
* In the CMakeLists.txt of the executables, remove `${CMAKE_BINARY_DIR}` of the install line : 
`install(TARGETS xxx DIRECTORY bin)`

These few tweaks made the libraries LandmarkDetector and FaceAnalyser install correctly. I apologize if I am mistaken somewhere, I might have missed something.

Note : I also added the SHARED tag instead of STATIC in the CMakeLists.txt, following issue #23 instructions. But not sure whether it is really relevant for this install issue.

Keep the work up, this is a fantastic tool !