### PR TITLE
Added the possibility to change the output videos codec 

### DIFF
--- a/exe/FaceLandmarkVid/FaceLandmarkVid.cpp
+++ b/exe/FaceLandmarkVid/FaceLandmarkVid.cpp
@@ -193,7 +193,8 @@ int main (int argc, char **argv)
 	
 	// Indicates that rotation should be with respect to world or camera coordinates
 	bool u;
-	LandmarkDetector::get_video_input_output_params(files, depth_directories, out_dummy, output_video_files, u, arguments);
+	string output_codec;
+	LandmarkDetector::get_video_input_output_params(files, depth_directories, out_dummy, output_video_files, u, output_codec, arguments);
 	
 	// The modules that are being used for tracking
 	LandmarkDetector::CLNF clnf_model(det_parameters.model_location);	
@@ -297,7 +298,14 @@ int main (int argc, char **argv)
 		cv::VideoWriter writerFace;
 		if (!output_video_files.empty())
 		{
-			writerFace = cv::VideoWriter(output_video_files[f_n], CV_FOURCC('D', 'I', 'V', 'X'), 30, captured_image.size(), true);
+			try
+ 			{
+				writerFace = cv::VideoWriter(output_video_files[f_n], CV_FOURCC(output_codec[0], output_codec[1], output_codec[2], output_codec[3]), 30, captured_image.size(), true);
+			}
+			catch(cv::Exception e)
+			{
+				WARN_STREAM( "Could not open VideoWriter, OUTPUT FILE WILL NOT BE WRITTEN. Currently using codec " << output_codec << ", try using an other one (-oc option)");
+			}
 		}
 
 		// Use for timestamping if using a webcam

--- a/exe/FaceLandmarkVidMulti/FaceLandmarkVidMulti.cpp
+++ b/exe/FaceLandmarkVidMulti/FaceLandmarkVidMulti.cpp
@@ -151,7 +151,8 @@ int main (int argc, char **argv)
 
 	// Get the input output file parameters
 	bool u;
-	LandmarkDetector::get_video_input_output_params(files, depth_directories, dummy_out, tracked_videos_output, u, arguments);
+	string output_codec;
+	LandmarkDetector::get_video_input_output_params(files, depth_directories, dummy_out, tracked_videos_output, u, output_codec, arguments);
 	// Get camera parameters
 	LandmarkDetector::get_camera_params(device, fx, fy, cx, cy, arguments);
 	
@@ -243,7 +244,14 @@ int main (int argc, char **argv)
 		cv::VideoWriter writerFace;
 		if(!tracked_videos_output.empty())
 		{
-			writerFace = cv::VideoWriter(tracked_videos_output[f_n], CV_FOURCC('D','I','V','X'), 30, captured_image.size(), true);
+			try
+			{
+				writerFace = cv::VideoWriter(tracked_videos_output[f_n], CV_FOURCC(output_codec[0],output_codec[1],output_codec[2],output_codec[3]), 30, captured_image.size(), true);
+			}
+			catch(cv::Exception e)
+			{
+				WARN_STREAM( "Could not open VideoWriter, OUTPUT FILE WILL NOT BE WRITTEN. Currently using codec " << output_codec << ", try using an other one (-oc option)");
+			}
 		}
 		
 		// For measuring the timings

--- a/exe/FeatureExtraction/FeatureExtraction.cpp
+++ b/exe/FeatureExtraction/FeatureExtraction.cpp
@@ -253,7 +253,8 @@ int main (int argc, char **argv)
 	
 	// Indicates that rotation should be with respect to camera or world coordinates
 	bool use_world_coordinates;
-	LandmarkDetector::get_video_input_output_params(input_files, depth_directories, output_files, tracked_videos_output, use_world_coordinates, arguments);
+	string output_codec; //not used but should
+	LandmarkDetector::get_video_input_output_params(input_files, depth_directories, output_files, tracked_videos_output, use_world_coordinates, output_codec, arguments);
 
 	bool video_input = true;
 	bool verbose = true;
@@ -490,7 +491,16 @@ int main (int argc, char **argv)
 		cv::VideoWriter writerFace;
 		if(!tracked_videos_output.empty())
 		{
-			writerFace = cv::VideoWriter(tracked_videos_output[f_n], CV_FOURCC('D', 'I', 'V', 'X'), fps_vid_in, captured_image.size(), true);
+			try
+			{
+				writerFace = cv::VideoWriter(tracked_videos_output[f_n], CV_FOURCC(output_codec[0],output_codec[1],output_codec[2],output_codec[3]), fps_vid_in, captured_image.size(), true);
+			}
+			catch(cv::Exception e)
+			{
+				WARN_STREAM( "Could not open VideoWriter, OUTPUT FILE WILL NOT BE WRITTEN. Currently using codec " << output_codec << ", try using an other one (-oc option)");
+			}
+
+			
 		}
 
 		int frame_count = 0;

--- a/lib/local/LandmarkDetector/include/LandmarkDetectorUtils.h
+++ b/lib/local/LandmarkDetector/include/LandmarkDetectorUtils.h
@@ -77,7 +77,7 @@ namespace LandmarkDetector
 	// Helper functions for parsing the inputs
 	//=============================================================================================
 	void get_video_input_output_params(vector<string> &input_video_file, vector<string> &depth_dir, vector<string> &output_files,
-		vector<string> &output_video_files, bool& world_coordinates_pose, vector<string> &arguments);
+		vector<string> &output_video_files, bool& world_coordinates_pose, string &output_codec, vector<string> &arguments);
 
 	void get_camera_params(int &device, float &fx, float &fy, float &cx, float &cy, vector<string> &arguments);
 

--- a/lib/local/LandmarkDetector/src/LandmarkDetectorUtils.cpp
+++ b/lib/local/LandmarkDetector/src/LandmarkDetectorUtils.cpp
@@ -121,7 +121,7 @@ void create_directories(string output_path)
 
 // Extracting the following command line arguments -f, -fd, -op, -of, -ov (and possible ordered repetitions)
 void get_video_input_output_params(vector<string> &input_video_files, vector<string> &depth_dirs, vector<string> &output_files,
-	vector<string> &output_video_files, bool& world_coordinates_pose, vector<string> &arguments)
+	vector<string> &output_video_files, bool& world_coordinates_pose, string& output_codec, vector<string> &arguments)
 {
 	bool* valid = new bool[arguments.size()];
 
@@ -132,6 +132,9 @@ void get_video_input_output_params(vector<string> &input_video_files, vector<str
 
 	// By default use rotation with respect to camera (not world coordinates)
 	world_coordinates_pose = false;
+
+    // By default use DIVX codec
+	output_codec = "DIVX";
 
 	string input_root = "";
 	string output_root = "";
@@ -196,6 +199,11 @@ void get_video_input_output_params(vector<string> &input_video_files, vector<str
 		else if (arguments[i].compare("-world_coord") == 0)
 		{
 			world_coordinates_pose = true;
+		}
+		else if (arguments[i].compare("-oc") == 0)
+		{
+			if(arguments[i + 1].length() == 4)
+				output_codec = arguments[i + 1];
 		}
 	}
 


### PR DESCRIPTION
This is achieved by implementing the -oc option
A warning is now issued in the case the VideoWriter could not be instantiated, advising to change the codec
This change applies to FaceLandmarkVid* and FeatureExtraction executables
The option is used as "-oc CODEC_FOURCC" and defaults to DIVX. If the user inputs a FOURCC with a size different than 4, than the default codec is used
The option is handled by the function get_video_input_output_params in the LandMarkDetector namespace