### PR TITLE
parameters: when fdloc provided, set detector to use HAAR cascade

### DIFF
--- a/lib/local/LandmarkDetector/src/LandmarkDetectorParameters.cpp
+++ b/lib/local/LandmarkDetector/src/LandmarkDetectorParameters.cpp
@@ -87,6 +87,7 @@ FaceModelParameters::FaceModelParameters(vector<string> &arguments)
 		{
 			string face_detector_loc = arguments[i + 1];
 			face_detector_location = face_detector_loc;
+			curr_face_detector = HAAR_DETECTOR;
 			valid[i] = false;
 			valid[i + 1] = false;
 			i++;


### PR DESCRIPTION
Hi @TadasBaltrusaitis, as you said in #202, I set the `curr_face_detector` to be `HAAR_DETECTOR` when `-fdloc` is specified :)