### PR TITLE
Fix OpenCV 3.4.0 build issue - cv::Mat_<> is broken in 3.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
 set(CMAKE_CONFIG_DIR etc/OpenFace)
 set(CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_CONFIG_DIR}")
-add_definitions(-DCONFIG_DIR="${CONFIG_DIR}")
+add_definitions(-DCONFIG_DIR="${CONFIG_DIR}" -DOPENCV_TRAITS_ENABLE_DEPRECATED)
 
 find_package( BLAS REQUIRED )
 include_directories( ${BLAS_INCLUDE_DIRS} )


### PR DESCRIPTION
I saw this fix in other discussions. This define shouldn't hurt anyone. OpenFace builds successfully with this.

OPENCV_TRAITS_ENABLE_DEPRECATED is mandatory in 3.4.0 since there's a glaring error in mat.hpp line 2153 in the cv::Mat_<> class, there's no other workaround possible.