### PR TITLE
Added support for AUs visualization to FeatureExtractor

### DIFF
--- a/exe/FeatureExtraction/FeatureExtraction.cpp
+++ b/exe/FeatureExtraction/FeatureExtraction.cpp
@@ -205,6 +205,7 @@ int main (int argc, char **argv)
 			visualizer.SetObservationLandmarks(face_model.detected_landmarks, face_model.detection_certainty, face_model.GetVisibilities());
 			visualizer.SetObservationPose(pose_estimate, face_model.detection_certainty);
 			visualizer.SetObservationGaze(gazeDirection0, gazeDirection1, LandmarkDetector::CalculateAllEyeLandmarks(face_model), LandmarkDetector::Calculate3DEyeLandmarks(face_model, sequence_reader.fx, sequence_reader.fy, sequence_reader.cx, sequence_reader.cy), face_model.detection_certainty);
+			visualizer.SetObservationActionUnits(face_analyser.GetCurrentAUsReg(), face_analyser.GetCurrentAUsClass());
 			visualizer.SetFps(fps_tracker.GetFPS());
 
 			// detect key presses

--- a/lib/local/Utilities/include/Visualizer.h
+++ b/lib/local/Utilities/include/Visualizer.h
@@ -66,7 +66,9 @@ namespace Utilities
 
 		// Pose related observations
 		void SetObservationPose(const cv::Vec6d& pose, double confidence);
-		
+
+		void SetObservationActionUnits(const std::vector<std::pair<std::string, double> >& au_intensities, const std::vector<std::pair<std::string, double> >& au_occurences);
+	
 		// Gaze related observations
 		void SetObservationGaze(const cv::Point3f& gazeDirection0, const cv::Point3f& gazeDirection1, const std::vector<cv::Point2d>& eye_landmarks, const std::vector<cv::Point3d>& eye_landmarks3d, double confidence);
 
@@ -88,6 +90,7 @@ namespace Utilities
 		bool vis_track;
 		bool vis_hog;
 		bool vis_align;
+		bool vis_aus;
 		
 		// Can be adjusted to show less confident frames
 		double visualisation_boundary = 0.4;
@@ -99,6 +102,7 @@ namespace Utilities
 		cv::Mat tracked_image;
 		cv::Mat hog_image;
 		cv::Mat aligned_face_image;
+		cv::Mat action_units_image;
 
 		// Useful for drawing 3d
 		float fx, fy, cx, cy;


### PR DESCRIPTION
This PR supersedes #376 (same PR, but on the `develop` branch).

![37468841-e0376010-285b-11e8-92a0-aa5099129302](https://user-images.githubusercontent.com/385379/37589215-7c687b42-2b5c-11e8-84ea-c500d1644429.png)

@TadasBaltrusaitis, compared to #376, the order of the AU is fixed (now, from AU01 to AU45, please disregard the older screenshot above).

However, I'm not sure to understand your other suggestion:

> the current version of the code assumes the configuration of AUs, but that might change so the AU names should actually be read in from the FaceAnalyser, it has a GetAURegNames() call that would help

`GetAURegNames` simply returns the strings `AU01` -> `AU45`. My code did not make any assumptions on these names (I got them from `FaceAnalyser::GetCurrentAUsReg()` that provide them as well). I only rely on these name to provide the long description. If you add a new AU in the future, the code will break if the long description is not available, but that probably good: it will ensure we do not forget to add such a description for new AUs in the future.

Regarding the Windows test not passing, the error (`OpenCV Error: Assertion failed (size.width>0 && size.height>0) in cv::imshow, file E:\software\opencv-3.4.0\modules\highgui\src\window.cpp, line` -- ie, empty image) when running `FaceLandmarkVid.exe`. This PR does not touch this sample app... Hard to debug for me as I do not have a Windows machine around...