### PR TITLE
Update Windows download script (#608)

### DIFF
--- a/download_models.ps1
+++ b/download_models.ps1
@@ -1,30 +1,42 @@
-# Download the models from the cloud (stored in Dropbox, OneDrive, and Google Drive
+# Download the models from the cloud (stored in Dropbox, OneDrive, and Google Drive)
+
+# Determine correct path to the model files
+if([System.IO.Directory]::Exists( (Join-Path (Get-Location) 'lib') ))
+{
+    # If the lib folder exists, code is compiled from source
+    $modelPath = "lib/local/LandmarkDetector/"
+}
+else
+{
+    # Otherwise, binaries are used
+    $modelPath = ""
+}
 
 # Start with 0.25 scale models
-$destination = "lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.25_of.dat"
+$destination = $modelPath + "model/patch_experts/cen_patches_0.25_of.dat"
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://www.dropbox.com/s/7na5qsjzz8yfoer/cen_patches_0.25_of.dat?dl=1"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://onedrive.live.com/download?cid=2E2ADA578BFF6E6E&resid=2E2ADA578BFF6E6E%2153072&authkey=AKqoZtcN0PSIZH4"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
 # 0.35 scale models
-$destination = "lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.35_of.dat"
+$destination = $modelPath + "model/patch_experts/cen_patches_0.35_of.dat"
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://www.dropbox.com/s/k7bj804cyiu474t/cen_patches_0.35_of.dat?dl=1"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://onedrive.live.com/download?cid=2E2ADA578BFF6E6E&resid=2E2ADA578BFF6E6E%2153079&authkey=ANpDR1n3ckL_0gs"
 	Invoke-WebRequest $source -OutFile $destination
@@ -32,30 +44,30 @@ if(!([System.IO.File]::Exists($destination)))
 
 
 # 0.5 scale models
-$destination = "lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.50_of.dat"
+$destination = $modelPath + "model/patch_experts/cen_patches_0.50_of.dat"
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://www.dropbox.com/s/ixt4vkbmxgab1iu/cen_patches_0.50_of.dat?dl=1"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://onedrive.live.com/download?cid=2E2ADA578BFF6E6E&resid=2E2ADA578BFF6E6E%2153074&authkey=AGi-e30AfRc_zvs"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
 # 1.0 scale models
-$destination = "lib/local/LandmarkDetector/model/patch_experts/cen_patches_1.00_of.dat"
+$destination = $modelPath + "model/patch_experts/cen_patches_1.00_of.dat"
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://www.dropbox.com/s/2t5t1sdpshzfhpj/cen_patches_1.00_of.dat?dl=1"
 	Invoke-WebRequest $source -OutFile $destination
 }
 
-if(!([System.IO.File]::Exists($destination)))
+if(!([System.IO.File]::Exists( (Join-Path (Get-Location) $destination) )))
 {
 	$source = "https://onedrive.live.com/download?cid=2E2ADA578BFF6E6E&resid=2E2ADA578BFF6E6E%2153070&authkey=AD6KjtYipphwBPc"
 	Invoke-WebRequest $source -OutFile $destination


### PR DESCRIPTION
Fixes issue #608.

During testing, I found that the `Exists` methods do not accept relative paths on my system (hence, each file was downloading twice). Even though the [official documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.exists?view=netframework-4.7.2) states otherwise, it is e.g. mentioned in [this wiki](https://www.powershelladmin.com/wiki/Powershell_check_if_folder_exists#Using_The_.NET_System.IO.Directory_Class_Method_.22Exists.22).

As a countermeasure, I also made all path checks absolute.