### PR TITLE
Improved Dockerfile building with OpenCV 3.4.6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 build
 matlab_runners
 matlab_version

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+lib/local/LandmarkDetector/model/patch_experts/*.dat
+
 matlab_version/experiments_menpo/out_semifrontal/
 /x64/Release/
 /x64/Debug/

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ lib/local/Utilities/Debug/
 lib/3rdParty/CameraEnumerator/Debug/
 lib/local/CppInerop/Debug/
 *.user
+
+# IDE-generated folders
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     MESSAGE("  OpenBLAS_INCLUDE: ${OpenBLAS_INCLUDE_DIR}")
 endif()
 
-find_package( OpenCV 3.3 REQUIRED COMPONENTS core imgproc calib3d highgui objdetect)
+find_package( OpenCV 3.4 REQUIRED COMPONENTS core imgproc calib3d highgui objdetect)
 if(${OpenCV_FOUND})
 	MESSAGE("OpenCV information:") 
 	MESSAGE("  OpenCV_INCLUDE_DIRS: ${OpenCV_INCLUDE_DIRS}") 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     MESSAGE("  OpenBLAS_INCLUDE: ${OpenBLAS_INCLUDE_DIR}")
 endif()
 
-find_package( OpenCV 3.4 REQUIRED COMPONENTS core imgproc calib3d highgui objdetect)
+find_package( OpenCV 3.3 REQUIRED COMPONENTS core imgproc calib3d highgui objdetect)
 if(${OpenCV_FOUND})
 	MESSAGE("OpenCV information:") 
 	MESSAGE("  OpenCV_INCLUDE_DIRS: ${OpenCV_INCLUDE_DIRS}") 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ RUN curl http://dlib.net/files/dlib-19.13.tar.bz2 -LO &&\
     mv dlib-19.13 dlib &&\
     mkdir -p dlib/build &&\
     cd dlib/build &&\
-    cmake -j "$((`nproc`<2?1:$((`nproc`-1))))" .. && \
-    cmake --build . --config Release && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. &&\
+    make -j "$((`nproc`<2?1:$((`nproc`-1))))" && \
     make install && \
     DESTDIR=/root/diff make install &&\
     ldconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,63 +1,116 @@
-FROM ubuntu:14.04 as build
+# ==================== Building Model Layer ===========================
+# This is a little trick to improve caching and minimize rebuild time
+# and bandwidth. Note that RUN commands only cache-miss if the prior layers
+# miss, or the dockerfile changes prior to this step.
+# To update these patch files, be sure to run build with --no-cache
+FROM alpine as model_data
+RUN apk --no-cache --update-cache add wget
+WORKDIR /data/patch_experts
+
+RUN wget -q https://www.dropbox.com/s/7na5qsjzz8yfoer/cen_patches_0.25_of.dat &&\
+    wget -q https://www.dropbox.com/s/k7bj804cyiu474t/cen_patches_0.35_of.dat &&\
+    wget -q https://www.dropbox.com/s/ixt4vkbmxgab1iu/cen_patches_0.50_of.dat &&\
+    wget -q https://www.dropbox.com/s/2t5t1sdpshzfhpj/cen_patches_1.00_of.dat
+
+# ==================== Install Ubuntu Base libs ===========================
+
+FROM ubuntu:18.04 as ubuntu_base
 
 LABEL maintainer="Edgar Aroutiounian <edgar.factorial@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG BUILD_DIR=/home/build-dep
-
-ARG OPENFACE_DIR=/home/openface-build
-
-RUN mkdir ${OPENFACE_DIR}
-WORKDIR ${OPENFACE_DIR}
-
-COPY ./CMakeLists.txt ${OPENFACE_DIR}
-
-COPY ./cmake ${OPENFACE_DIR}/cmake
-
-COPY ./exe ${OPENFACE_DIR}/exe
-
-COPY ./lib ${OPENFACE_DIR}/lib
-
-ADD https://www.dropbox.com/s/7na5qsjzz8yfoer/cen_patches_0.25_of.dat?dl=1 \
-    ${OPENFACE_DIR}/lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.25_of.dat
-
-ADD https://www.dropbox.com/s/k7bj804cyiu474t/cen_patches_0.35_of.dat?dl=1 \
-    ${OPENFACE_DIR}/lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.35_of.dat
-
-ADD https://www.dropbox.com/s/ixt4vkbmxgab1iu/cen_patches_0.50_of.dat?dl=1 \
-    ${OPENFACE_DIR}/lib/local/LandmarkDetector/model/patch_experts/cen_patches_0.50_of.dat
-
-ADD https://www.dropbox.com/s/2t5t1sdpshzfhpj/cen_patches_1.00_of.dat?dl=1 \
-    ${OPENFACE_DIR}/lib/local/LandmarkDetector/model/patch_experts/cen_patches_1.00_of.dat
-
-RUN mkdir ${BUILD_DIR}
-
-ADD https://github.com/opencv/opencv/archive/3.4.0.zip ${BUILD_DIR}
-
-RUN apt-get update && apt-get install -qq -y \
-    curl build-essential llvm clang-3.7 libc++-dev \
-    libc++abi-dev cmake libopenblas-dev liblapack-dev git libgtk2.0-dev \
-    pkg-config libavcodec-dev libavformat-dev libswscale-dev \
-    python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev \
-    libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev checkinstall \
-    libboost-all-dev wget unzip && \
+# todo: minimize this even more
+RUN apt-get update -qq && apt-get install -qq curl \
+    && apt-get install -qq --no-install-recommends \
+        cmake \
+        libc++abi-dev libopenblas-dev liblapack-dev \
+        pkg-config libavcodec-dev libavformat-dev libswscale-dev \
+        libtbb2 libtbb-dev libjpeg-dev \
+        libpng-dev libtiff-dev \
+        libboost-all-dev  && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cd ${BUILD_DIR} && unzip 3.4.0.zip && \
-    cd opencv-3.4.0 && \
-    mkdir -p build && \
-    cd build && \
+# Tip: Install pip with get-pip is official preffered method
+RUN curl --silent --show-error \
+    https://bootstrap.pypa.io/get-pip.py | python2 &&\
+    pip2 install --no-cache-dir numpy==1.16
+
+# ==================== Build-time dependency libs ======================
+# This will build and install opencv and dlib into an additional dummy
+# directory, /root/diff, so we can later copy in these artifacts,
+# minimizing docker layer size
+FROM ubuntu_base as cv_deps
+
+WORKDIR /root/build-dep
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -qq -y \
+        build-essential llvm clang-3.7 libc++-dev \
+        python-dev git checkinstall&& \
+    rm -rf /var/lib/apt/lists/*
+
+# ==================== Building dlib ===========================
+
+RUN curl http://dlib.net/files/dlib-19.13.tar.bz2 -LO &&\
+    tar xf dlib-19.13.tar.bz2 && \
+    rm dlib-19.13.tar.bz2 &&\
+    mv dlib-19.13 dlib &&\
+    mkdir -p dlib/build &&\
+    cd dlib/build &&\
+    cmake -j "$((`nproc`<2?1:$((`nproc`-1))))" .. && \
+    cmake --build . --config Release && \
+    make install && \
+    DESTDIR=/root/diff make install &&\
+    ldconfig
+
+# ==================== Building OpenCV ======================
+ENV OPENCV_VERSION=3.4.6
+
+RUN curl https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz -LO &&\
+    tar xf ${OPENCV_VERSION}.tar.gz && \
+    rm ${OPENCV_VERSION}.tar.gz &&\
+    mv opencv-${OPENCV_VERSION} opencv && \
+    mkdir -p opencv/build && \
+    cd opencv/build && \
     cmake -D CMAKE_BUILD_TYPE=RELEASE \
     -D CMAKE_INSTALL_PREFIX=/usr/local \
     -D WITH_TBB=ON -D WITH_CUDA=OFF \
-    -D BUILD_SHARED_LIBS=OFF .. && \
-    make -j4 && \
-    make install
+    -DWITH_QT=OFF -DWITH_GTK=OFF\
+    .. && \
+    make -j "$((`nproc`<2?1:$((`nproc`-1))))" && \
+    make install &&\
+    DESTDIR=/root/diff make install
 
-RUN cd ${OPENFACE_DIR} && mkdir -p build && cd build && \
+# ==================== Building OpenFace ===========================
+FROM cv_deps as openface
+WORKDIR /root/openface
+
+COPY ./CMakeLists.txt ./
+
+COPY ./cmake ./cmake
+
+COPY ./exe ./exe
+
+COPY ./lib ./lib
+
+COPY --from=model_data /data/patch_experts/* \
+    /root/openface/lib/local/LandmarkDetector/model/patch_experts/
+
+RUN mkdir -p build && cd build && \
     cmake -D CMAKE_BUILD_TYPE=RELEASE .. && \
-    make -j4
+    make -j "$((`nproc`<2?1:$((`nproc`-1))))" &&\
+    DESTDIR=/root/diff make install
 
-RUN ln /dev/null /dev/raw1394
-ENTRYPOINT ["/bin/bash"]
+
+# ==================== Streamline container ===========================
+# Clean up - start fresh and only copy in necessary stuff
+# This shrinks the image from ~8 GB to ~1.6 GB
+FROM ubuntu_base as final
+
+WORKDIR /root
+
+# Copy in only necessary libraries
+COPY --from=openface /root/diff /
+
+RUN ldconfig

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+# Variables can be set from the shell: `DOCKERTAG=foo docker-compose build`
+# or from a .env file. See docker-compose documentation for details
+# Variable DOCKERUSER should be set to your dockerhub user
+# Alternatively, use a docker registry url as the image name
+version: '3.7'
+services:
+  openface:
+    container_name: openface
+    build:
+      context: .
+      dockerfile: Dockerfile
+    tty: true
+    image: "${DOCKERUSER:-openface}/openface:${DOCKERTAG:-latest}"
+    command: ["bash"]
+
+...


### PR DESCRIPTION
Improved Dockerfile and added docker-compose file for ease of tagging. CMakeLists.txt updated to use OpenCV 3.4, since that seemed more consistent with the current install instructions. 

- Uses staged builds to improve caching and reduce image size. 
- Image size reduced from 8 GB to 1.6 GB
- `make` builds with `-j "$((`nproc`<2?1:$((`nproc`-1))))" ` for faster builds that don't freeze host system completely
- Removed unneeded dependencies like gtk2 (because headless), 1394 (doesn't need firewire)
- Cleaned up python dependencies
- .git added to dockerignore to reduce build context size

I am not sure what the full test suite is, but I have been firing the binaries at various images and the output looks good. 