### PR TITLE
Add missing header ConcurrentQueue.h in cmake build

### DIFF
--- a/lib/local/Utilities/CMakeLists.txt
+++ b/lib/local/Utilities/CMakeLists.txt
@@ -17,7 +17,8 @@ SET(HEADERS
 	include/RecorderOpenFaceParameters.h
 	include/SequenceCapture.h
 	include/VisualizationUtils.h
-	include/Visualizer.h	
+	include/Visualizer.h
+	include/ConcurrentQueue.h
 )
 
 add_library( Utilities ${SOURCE} ${HEADERS})


### PR DESCRIPTION
While using your SequenceCapture class I got this error regarding missing ConcurrentQueue.h      
```
/usr/local/include/OpenFace/SequenceCapture.h:48:10: fatal error: ConcurrentQueue.h: No such file or directory
 #include <ConcurrentQueue.h>
          ^~~~~~~~~~~~~~~~~~~
```
Turns out that CmakeLists.txt did not include the header. Just a minor change to fix this.