### PR TITLE
Updated OpenFaceConfig.cmake

### DIFF
--- a/cmake/OpenFaceConfig.cmake.in
+++ b/cmake/OpenFaceConfig.cmake.in
@@ -3,8 +3,8 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(dlib 18.18)
-find_dependency(OpenCV 3.3)
+find_dependency(dlib 19.13)
+find_dependency(OpenCV 3.4)
 find_dependency(Boost)
 find_dependency(BLAS)
 find_dependency(TBB)

--- a/cmake/OpenFaceConfig.cmake.in
+++ b/cmake/OpenFaceConfig.cmake.in
@@ -11,8 +11,10 @@ find_dependency(TBB)
 
 include("${CMAKE_CURRENT_LIST_DIR}/OpenFaceTargets.cmake")
 
-set_and_check(OpenFace_INCLUDE_DIRS "@PACKAGE_OPENFACE_INCLUDE_DIRS@;
-                            ${dlib_INCLUDE_DIRS};
-                            ${Boost_INCLUDE_DIRS};
-                            ${Boost_INCLUDE_DIRS}/boost;")
+set(OpenFace_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/OpenFace)
+list(APPEND OpenFace_INCLUDE_DIRS ${dlib_INCLUDE_DIRS})
+list(APPEND OpenFace_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
+list(APPEND OpenFace_INCLUDE_DIRS ${Boost_INCLUDE_DIRS}/boost)
+set_and_check(OpenFace_INCLUDE_DIRS ${OpenFace_INCLUDE_DIRS})
+
 set(OpenFace_LIBRARIES @OpenFace_LIBRARIES@)

--- a/cmake/OpenFaceConfig.cmake.in
+++ b/cmake/OpenFaceConfig.cmake.in
@@ -11,10 +11,9 @@ find_dependency(TBB)
 
 include("${CMAKE_CURRENT_LIST_DIR}/OpenFaceTargets.cmake")
 
-set(OpenFace_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/OpenFace)
+set_and_check(OpenFace_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/OpenFace)
 list(APPEND OpenFace_INCLUDE_DIRS ${dlib_INCLUDE_DIRS})
 list(APPEND OpenFace_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
 list(APPEND OpenFace_INCLUDE_DIRS ${Boost_INCLUDE_DIRS}/boost)
-set_and_check(OpenFace_INCLUDE_DIRS ${OpenFace_INCLUDE_DIRS})
 
 set(OpenFace_LIBRARIES @OpenFace_LIBRARIES@)


### PR DESCRIPTION
I was having trouble using the config for cmake because the set_and_check function was checking if a given file existed, but it was called with a list of files. Updated the config file so that it only checks for the OpenFace headers. Also updated the versions of the dependencies. They didn't seem to match the installation instructions for Ubuntu.