### PR TITLE
Do not apt remove cmake on Ubuntu != 18.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,9 +37,7 @@ sudo apt-get -y install build-essential
 sudo apt-get -y install gcc-8 g++-8
 
 # Ubuntu 16.04 does not have newest CMake so need to build it manually
-if [[ `lsb_release -rs` != "18.04" ]]; then   
-  sudo apt-get --purge remove cmake-qt-gui -y
-  sudo apt-get --purge remove cmake -y
+if [[ `lsb_release -rs` < "18.04" ]]; then   
   mkdir -p cmake_tmp
   cd cmake_tmp
   wget https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz
@@ -50,6 +48,7 @@ if [[ `lsb_release -rs` != "18.04" ]]; then
   sudo make install
   cd ../..
   sudo rm -r cmake_tmp
+  export PATH=/usr/local/bin:$PATH
 else
   sudo apt-get -y install cmake
 fi


### PR DESCRIPTION
Removing cmake using `apt remove` also removes other packages depends on the cmake. For instance, in my case `ros_kinetic_catkin` is removed, and it causes hundreds of ros packages removed in the end.

To avoid this unexpected package remove, just keep the cmake package as is, install newer cmake in /usr/local/bin, and use the newer one to build the OpenFace.